### PR TITLE
Update the ProjectManipulator for the new templates

### DIFF
--- a/setup/ProjectManipulator.rb
+++ b/setup/ProjectManipulator.rb
@@ -74,8 +74,8 @@ module Pod
       podfile_path = project_folder + "/Podfile"
       podfile_lines = File.read(podfile_path).lines
       3.times do  podfile_lines.delete_at 3 end
-      # Remove the last line containing the matching "end"
-      podfile_lines.pop
+      podfile_lines.delete_at 4 # inherit-statement
+      podfile_lines.pop  # `end` matching the target
       podfile_text = podfile_lines.join
       File.open(podfile_path, "w") { |file| file.puts podfile_text }
     end

--- a/setup/ProjectManipulator.rb
+++ b/setup/ProjectManipulator.rb
@@ -74,6 +74,8 @@ module Pod
       podfile_path = project_folder + "/Podfile"
       podfile_lines = File.read(podfile_path).lines
       3.times do  podfile_lines.delete_at 3 end
+      # Remove the last line containing the matching "end"
+      podfile_lines.pop
       podfile_text = podfile_lines.join
       File.open(podfile_path, "w") { |file| file.puts podfile_text }
     end


### PR DESCRIPTION
The new templates wrap a the Test target inside the Example target but only the top three lines were removed from the Podfile but not the `end` line matching the `target`.
